### PR TITLE
adds reenqueue by name processor

### DIFF
--- a/lib/deadletterProcessors/reenqueueByName.js
+++ b/lib/deadletterProcessors/reenqueueByName.js
@@ -1,0 +1,12 @@
+const deadletterActions = require('./../deadletterActions');
+const Q = require('q');
+
+module.exports = function(event, message) {
+  const content = JSON.parse(message.content);
+
+  if (event === content.event) {
+    return Q.when(deadletterActions.REENQUEUE_MESSAGE);
+  } else {
+    return Q.reject(new Error(`Required ${event} does not match ${message.content.event}`));
+  }
+};

--- a/test/deadLetterProcessors.js
+++ b/test/deadLetterProcessors.js
@@ -56,6 +56,26 @@ describe('Deadletter processors', function() {
     });
   });
 
+  describe('Re-Enqueue by Name Processor', function() {
+
+    it('should return with a promise containing requeue all messages action when the event name matches', function() {
+      const event = this.messageContent.event;
+
+      return DeadLetterProcessors.reenqueueByName(event, this.message).then(function(result) {
+        assert.equal(result, DeadletterActions.REENQUEUE_MESSAGE);
+      });
+    });
+
+    it('should reject promise when the event name doesn\'t match', function() {
+      return DeadLetterProcessors.reenqueueByName('anyOtherEvent', this.message).then(function() {
+        return Q.reject(new Error('Should have failed'));
+      }, function() {
+        return Q.resolve();
+      });
+    });
+
+  });
+
   describe('StdIn Processor', function() {
 
     it('when we respond with "1" we should reenqueue', function() {


### PR DESCRIPTION
We need a way to process large number of deadletter events by filtering specific events. 

This processor just takes an event name as a property and enqueues matching events.